### PR TITLE
[RHTAPUI-54] TestItem export and import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ Thumbs.db
 /testplan.json
 /kubeconfig
 /package-lock.json
+tmp
 
 # Tekton
 .tekton/
+

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -10,8 +10,12 @@ async function globalSetup(config: FullConfig) {
   log.info('Starting test suite setup (Global Setup)');
 
   try {
-    // Reset the test items file for this run
-    resetTestItemsFile();
+    // Skip reset when running UI tests
+    const isUITest = process.env.UI_TEST === 'true';
+
+    if (!isUITest) {
+      resetTestItemsFile();
+    }
 
     log.info('Global setup completed successfully.');
   } catch (error) {

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -1,6 +1,8 @@
+// Import default logger as fallback
+import { closeAllLoggers, defaultLogger } from './src/log/logger';
+import { resetTestItemsFile } from './src/utils/testItemExporter';
 import { FullConfig } from '@playwright/test';
-import { Logger } from 'pino'; // Import Logger type
-import { closeAllLoggers, defaultLogger } from './src/log/logger'; // Import default logger as fallback
+import { Logger } from 'pino';
 
 async function globalSetup(config: FullConfig) {
   const log: Logger = defaultLogger;
@@ -8,9 +10,8 @@ async function globalSetup(config: FullConfig) {
   log.info('Starting test suite setup (Global Setup)');
 
   try {
-    // --- Your existing global setup logic here ---
-    // Example: log.debug('Performing pre-suite actions...');
-    // ---
+    // Reset the test items file for this run
+    resetTestItemsFile();
 
     log.info('Global setup completed successfully.');
   } catch (error) {
@@ -24,5 +25,6 @@ async function globalTeardown(config: FullConfig) {
   console.log('Ensuring all logs are properly flushed to disk...');
   await closeAllLoggers();
 }
+
 export { globalTeardown };
 export default globalSetup;

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
         "test": "playwright test",
         "test:report": "playwright show-report",
         "test:tssc": "playwright test tests/tssc/full_workflow.test.ts",
-        "test:ui": "playwright test tests/tssc/ui.test.ts",
-        "ui": "playwright test --ui tests/tssc/ui.test.ts"
+        "test:ui": "UI_TEST=true playwright test tests/tssc/ui.test.ts",
+        "ui": "UI_TEST=true playwright test --ui tests/tssc/ui.test.ts"
     },
     "keywords": [
         "typescript",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, PlaywrightTestConfig, PlaywrightTestOptions, PlaywrightWorkerOptions } from '@playwright/test';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import path from 'path';
 import { TestPlan } from './src/playwright/testplan';
 import { TestItem } from './src/playwright/testItem';
@@ -11,25 +11,47 @@ declare module '@playwright/test' {
   }
 }
 
-// Load the test plan
+// Load the test plan for e2e tests
 const testPlanPath = process.env.TESTPLAN_PATH || path.resolve(process.cwd(), 'testplan.json');
 const testPlanData = JSON.parse(readFileSync(testPlanPath, 'utf-8'));
 const testPlan = new TestPlan(testPlanData);
 
 // Create projects using the TestPlan class
-const projects = testPlan.getProjectConfigs().map(config => ({
+const e2eProjects = testPlan.getProjectConfigs().map(config => ({
   name: config.name,
   use: {
     testItem: config.testItem,
   },
 }));
 
+// Create ui projects for UI tests from exported test items
+let uiProjects: any[] = [];
+const exportedTestItemsPath = './tmp/test-items.json';
+if (existsSync(exportedTestItemsPath)) {
+  try {
+    const exportedData = JSON.parse(readFileSync(exportedTestItemsPath, 'utf-8'));
+    if (exportedData.testItems && Array.isArray(exportedData.testItems)) {
+      uiProjects = exportedData.testItems.map((itemData: any) => ({
+        name: `ui-${itemData.name}`,
+        testMatch: '**/ui.test.ts',
+        use: {
+          testItem: TestItem.fromJSON(itemData),
+        },
+      }));
+    }
+  } catch (error) {
+    console.warn('Could not load exported test items for UI tests:', error);
+  }
+}
+
+const allProjects = [...e2eProjects, ...uiProjects];
+
 export default defineConfig({
   testDir: './tests',
   testMatch: '**/*.test.ts',
   workers: 6,
-  projects: projects.length ? projects : [{ name: 'default' }],
-  reporter: [['html', { open: 'never' }], ['list']],
+  projects: allProjects.length ? allProjects : [{ name: 'default' }],
+  reporter: [['html'], ['list']],
   timeout: 900000, // Default to 15 minutes (900000ms)
   globalSetup: './global-setup.ts',
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,4 +31,5 @@ export default defineConfig({
   projects: projects.length ? projects : [{ name: 'default' }],
   reporter: [['html', { open: 'never' }], ['list']],
   timeout: 900000, // Default to 15 minutes (900000ms)
+  globalSetup: './global-setup.ts',
 });

--- a/src/playwright/testItem.ts
+++ b/src/playwright/testItem.ts
@@ -4,6 +4,7 @@ import { TemplateType } from '../../src/rhtap/core/integration/git';
 import { ImageRegistryType } from '../../src/rhtap/core/integration/registry';
 
 export class TestItem {
+  private name: string;
   private template: TemplateType;
   private registryType: ImageRegistryType;
   private gitType: GitType;
@@ -12,6 +13,7 @@ export class TestItem {
   private acs: string;
 
   constructor(
+    name: string,
     template: TemplateType,
     registryType: ImageRegistryType,
     gitType: GitType,
@@ -19,6 +21,7 @@ export class TestItem {
     tpa: string = '',
     acs: string = ''
   ) {
+    this.name = name;
     this.template = template;
     this.registryType = registryType;
     this.gitType = gitType;
@@ -28,6 +31,10 @@ export class TestItem {
   }
 
   // Getters
+  public getName(): string {
+    return this.name;
+  }
+
   public getTemplate(): TemplateType {
     return this.template;
   }
@@ -53,6 +60,10 @@ export class TestItem {
   }
 
   // Setters
+  public setName(name: string): void {
+    this.name = name;
+  }
+
   public setTemplate(template: TemplateType): void {
     this.template = template;
   }
@@ -75,5 +86,35 @@ export class TestItem {
 
   public setACS(acs: string): void {
     this.acs = acs;
+  }
+
+  /**
+   * Convert the TestItem to a JSON-serializable object
+   */
+  public toJSON(): object {
+    return {
+      name: this.name,
+      template: this.template,
+      registryType: this.registryType,
+      gitType: this.gitType,
+      ciType: this.ciType,
+      tpa: this.tpa,
+      acs: this.acs,
+    };
+  }
+
+  /**
+   * Create a TestItem from a JSON object
+   */
+  public static fromJSON(data: Record<string, unknown>): TestItem {
+    return new TestItem(
+      data.name as string,
+      data.template as TemplateType,
+      data.registryType as ImageRegistryType,
+      data.gitType as GitType,
+      data.ciType as CIType,
+      data.tpa as string,
+      data.acs as string
+    );
   }
 }

--- a/src/playwright/testplan.ts
+++ b/src/playwright/testplan.ts
@@ -1,7 +1,8 @@
-import { CIType } from '../rhtap/core/integration/ci';
-import { GitType } from '../rhtap/core/integration/git';
-import { TemplateType } from '../rhtap/core/integration/git/templates/templateFactory';
-import { ImageRegistryType } from '../rhtap/core/integration/registry';
+import { CIType } from '../../src/rhtap/core/integration/ci';
+import { GitType } from '../../src/rhtap/core/integration/git';
+import { TemplateType } from '../../src/rhtap/core/integration/git';
+import { ImageRegistryType } from '../../src/rhtap/core/integration/registry';
+import { randomString } from '../utils/util';
 import { TestItem } from './testItem';
 
 export interface TSScConfig {
@@ -44,6 +45,7 @@ export class TestPlan {
       this.tsscConfigs.forEach(tsscConfig => {
         testItems.push(
           new TestItem(
+            `${template}-${randomString()}`,
             template as TemplateType,
             tsscConfig.registry,
             tsscConfig.git,
@@ -69,6 +71,7 @@ export class TestPlan {
         projects.push({
           name: `${template}[${tsscConfig.git}-${tsscConfig.ci}-${tsscConfig.registry}]`,
           testItem: new TestItem(
+            `${template}-${randomString()}`,
             template as TemplateType,
             tsscConfig.registry,
             tsscConfig.git,

--- a/src/utils/test/common.ts
+++ b/src/utils/test/common.ts
@@ -146,7 +146,15 @@ export function getTestItemFromEnv(): TestItem {
   }
   try {
     const obj = JSON.parse(raw);
-    return new TestItem(obj.template, obj.registryType, obj.gitType, obj.ciType, obj.tpa, obj.acs);
+    return new TestItem(
+      obj.name,
+      obj.template,
+      obj.registryType,
+      obj.gitType,
+      obj.ciType,
+      obj.tpa,
+      obj.acs
+    );
   } catch (e) {
     throw new Error(`Failed to parse TESTITEM: ${e}`);
   }

--- a/src/utils/testItemExporter.ts
+++ b/src/utils/testItemExporter.ts
@@ -1,0 +1,63 @@
+import { TestItem } from '../playwright/testItem';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+
+/**
+ * Add a test item to a JSON file containing all test items from current run
+ */
+export function exportTestItem(
+  testItem: TestItem,
+  outputPath: string = './tmp/test-items.json'
+): void {
+  // Create output directory if it doesn't exist
+  const outputDir = dirname(outputPath);
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+
+  let exportData: any = {
+    testItems: [],
+    totalTestItems: 0,
+  };
+
+  // Read existing file
+  if (existsSync(outputPath)) {
+    try {
+      const existingData = JSON.parse(readFileSync(outputPath, 'utf-8'));
+      exportData = existingData;
+    } catch (error) {
+      console.warn('Could not read existing file, creating new one');
+    }
+  }
+
+  // Add the new test item
+  const newTestItemData = {
+    ...testItem.toJSON(),
+  };
+
+  exportData.testItems.push(newTestItemData);
+  exportData.totalTestItems = exportData.testItems.length;
+  console.log(`➕ Added test item: ${testItem.getName()}`);
+
+  // Write back to file
+  writeFileSync(outputPath, JSON.stringify(exportData, null, 2));
+  console.log(`✅ Updated file with ${exportData.totalTestItems} test items: ${outputPath}`);
+}
+
+/**
+ * Reset the test items file
+ */
+export function resetTestItemsFile(outputPath: string = './tmp/test-items.json'): void {
+  const outputDir = dirname(outputPath);
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+
+  const exportData = {
+    testItems: [],
+    totalTestItems: 0,
+  };
+
+  writeFileSync(outputPath, JSON.stringify(exportData, null, 2));
+  console.log(`🔄 Reset test items file: ${outputPath}`);
+}

--- a/tests/tssc/full_workflow.test.ts
+++ b/tests/tssc/full_workflow.test.ts
@@ -9,7 +9,7 @@ import {
   promoteToEnvironmentWithPR,
 } from '../../src/utils/test/common';
 import { createBasicFixture } from '../../src/utils/test/fixtures';
-import { randomString } from '../../src/utils/util';
+import { exportTestItem } from '../../src/utils/testItemExporter';
 import { expect } from '@playwright/test';
 
 /**
@@ -35,10 +35,15 @@ test.describe('TSSC Complete Workflow', () => {
   let git: Git;
   let image: string = '';
 
+  // Add current test item to consolidated JSON file
+  test.beforeAll(async ({ testItem }) => {
+    exportTestItem(testItem);
+  });
+
   test.describe('Component Creation', () => {
     test('should create a component successfully', async ({ testItem }) => {
       // Generate component name directly in the test
-      const componentName = `${testItem.getTemplate()}-${randomString()}`;
+      const componentName = testItem.getName();
       const imageName = `${componentName}`;
       console.log(`Creating component: ${componentName}`);
 

--- a/tests/tssc/full_workflow.test.ts
+++ b/tests/tssc/full_workflow.test.ts
@@ -35,9 +35,11 @@ test.describe('TSSC Complete Workflow', () => {
   let git: Git;
   let image: string = '';
 
-  // Add current test item to consolidated JSON file
-  test.beforeAll(async ({ testItem }) => {
-    exportTestItem(testItem);
+  test.afterAll(async ({ testItem }, testInfo) => {
+    // Export test item only if all tests succeed
+    if (testInfo.status === 'passed') {
+      exportTestItem(testItem);
+    }
   });
 
   test.describe('Component Creation', () => {

--- a/tests/tssc/ui.test.ts
+++ b/tests/tssc/ui.test.ts
@@ -26,6 +26,7 @@ test.describe('RHTAP UI Test Suite', () => {
   let component: UiComponent;
 
   test.beforeAll('', async ({ testItem }) => {
+    console.log('Running UI test for:', testItem);
     const componentName = loadFromEnv('IMAGE_REGISTRY_ORG');
     const imageName = `${componentName}`;
     console.log(`Creating component: ${componentName}`);


### PR DESCRIPTION
This PR implements TestItem export, so the TestItems can be used for reference in the UI tests later.

Issue: [RHTAPUI-54](https://issues.redhat.com/browse/RHTAPUI-54)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced test item management with support for naming, JSON export/import, and unique identification.
  - Added functionality to export and reset test items to a JSON file for improved test tracking.

- **Improvements**
  - Playwright configuration now dynamically generates projects for both end-to-end and UI tests based on external JSON files.
  - Test setup logic now conditionally resets test items, skipping this step for UI tests to streamline workflows.
  - Test logging improved to provide clearer feedback during UI test execution.
  - UI test runs now include environment variable settings to better control test behavior.

- **Chores**
  - Updated ignored files to exclude temporary directories from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->