### PR TITLE
fixed reporter issue

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
   testMatch: '**/*.test.ts',
   workers: 6,
   projects: allProjects.length ? allProjects : [{ name: 'default' }],
-  reporter: [['html'], ['list']],
+  reporter: [['html', { open: 'never' }], ['list']],
   timeout: 900000, // Default to 15 minutes (900000ms)
   globalSetup: './global-setup.ts',
 });


### PR DESCRIPTION
Issues:

Because PR#[21](https://github.com/redhat-appstudio/tssc-test/pull/21/files) removed the following HTML reporter property, it caused the e2e ci task is stuck there.
```
[['html', { open: 'never' }]
``` 