### PR TITLE
Fix SBOM verification

### DIFF
--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -9,7 +9,7 @@
     },
     {
       "git": "gitlab",
-      "ci": "tekton",
+      "ci": "gitlabci",
       "registry": "quay.io",
       "tpa": "local",
       "acs": "remote"

--- a/tests/tssc/full_workflow.test.ts
+++ b/tests/tssc/full_workflow.test.ts
@@ -131,7 +131,7 @@ test.describe('TSSC Complete Workflow', () => {
       test.skip(!image, 'No image available to verify SBOM');
 
       // Extract image digest from image URL
-      const imageDigest = image.split(':')[2];
+      const imageDigest = image.split(':').pop() || '';
       expect(imageDigest).toBeTruthy();
 
       // Get TPA instance and search for SBOM


### PR DESCRIPTION
Image tagging is different for different CI, update the SBOM verification step to work with all CIs.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI system designation for GitLab repositories in the test plan configuration.

* **Tests**
  * Improved the extraction method for image digests in SBOM verification tests for greater reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->