### PR TITLE
RHTAP-5294 - remove quay automation configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ The testplan.json file supports defining multiple TSSC combinations, allowing yo
     {
       "git": "github",
       "ci": "tekton",
-      "registry": "quay.io",
+      "registry": "quay",
       "tpa": "remote",
       "acs": "local"
     },
     {
       "git": "gitlab",
       "ci": "tekton",
-      "registry": "quay.io",
+      "registry": "quay",
       "tpa": "remote",
       "acs": "local"
     }
@@ -67,7 +67,7 @@ The testplan.json file supports defining multiple TSSC combinations, allowing yo
 - **`tssc`**: Array of TSSC configuration objects, each containing:
   - `git`: Git provider - `["github", "gitlab", "bitbucket"]`
   - `ci`: CI provider - `["tekton", "jenkins", "gitlabci", "githubactions"]`
-  - `registry`: Image registry - `["quay", "quay.io", "artifactory", "nexus"]`
+  - `registry`: Image registry - `["quay","artifactory", "nexus"]`
   - `acs`: ACS configuration - `["local", "remote"]`
   - `tpa`: TPA configuration - `["local", "remote"]`
 
@@ -77,7 +77,7 @@ The testplan.json file supports defining multiple TSSC combinations, allowing yo
 
 The framework creates a test matrix by combining each template with each TSSC configuration. For example, with the above configuration:
 - **Templates**: 6 (go, python, nodejs, dotnet-basic, java-quarkus, java-springboot)
-- **TSSC combinations**: 2 (github+tekton+quay.io, gitlab+tekton+quay.io)
+- **TSSC combinations**: 2 (github+tekton+quay, gitlab+tekton+quay)
 - **Total tests**: 6 × 2 = 12 test combinations
 
 Each test combination runs independently, allowing you to validate different technology stacks across various TSSC configurations.

--- a/integration-tests/config/rhads-config
+++ b/integration-tests/config/rhads-config
@@ -1,6 +1,6 @@
 OCP="4.18"
 ACS="remote"
-REGISTRY="quay.io,artifactory,nexus"
+REGISTRY="quay,artifactory,nexus"
 TPA="remote"
 SCM="github,gitlab,bitbucket"
 PIPELINE="tekton,actions,gitlabci,jenkins"

--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -3,7 +3,7 @@
   "tssc": [{
     "git": "github",
     "ci": "tekton",
-    "registry": "quay.io",
+    "registry": "quay",
     "tpa": "remote",
     "acs": "remote"
   },
@@ -24,14 +24,14 @@
   {
     "git": "gitlab",
     "ci": "gitlabci",
-    "registry": "quay.io",
+    "registry": "quay",
     "tpa": "remote",
     "acs": "remote"
   },
   {
     "git": "github",
     "ci": "jenkins",
-    "registry": "quay.io",
+    "registry": "quay",
     "tpa": "remote",
     "acs": "remote"
   }],

--- a/src/rhtap/core/integration/registry/imageRegistry.ts
+++ b/src/rhtap/core/integration/registry/imageRegistry.ts
@@ -2,7 +2,6 @@ import { KubeClient } from './../../../../../src/api/ocp/kubeClient';
 
 export enum ImageRegistryType {
   QUAY = 'quay',
-  QUAYIO = 'quay.io',
   ARTIFACTORY = 'artifactory',
   NEXUS = 'nexus',
 }
@@ -14,7 +13,7 @@ export interface ImageRegistry {
   getImageName(): string;
 
   /**
-   * The format is {"auths":{"quay.io":{"auth":"base64encoded", "email":""}}}
+   * The format is {"auths":{"<image-registry-host-url>":{"auth":"base64encoded", "email":""}}}
    */
   getDockerConfig(): string;
   getImageRegistryUser(): string;

--- a/src/rhtap/core/integration/registry/providers/quayRegistry.ts
+++ b/src/rhtap/core/integration/registry/providers/quayRegistry.ts
@@ -9,10 +9,6 @@ export class QuayRegistry extends BaseImageRegistry {
   }
 
   public getRegistryType(): ImageRegistryType {
-    //if registry host is quay.io, return QUAYIO
-    if (this.getRegistryHost() === 'quay.io') {
-      return ImageRegistryType.QUAYIO;
-    }
     return ImageRegistryType.QUAY;
   }
 

--- a/src/rhtap/core/integration/registry/registryFactory.ts
+++ b/src/rhtap/core/integration/registry/registryFactory.ts
@@ -51,7 +51,6 @@ export class RegistryFactory {
     let imageOrg;
     switch (imageRegistryType) {
       case ImageRegistryType.QUAY:
-      case ImageRegistryType.QUAYIO:
         imageOrg = loadFromEnv('QUAY_REGISTRY_ORG');
         const quayRegistry = new QuayRegistry(imageOrg, imageName);
         quayRegistry.setKubeClient(this.kubeClient);

--- a/templates/testplan.json
+++ b/templates/testplan.json
@@ -4,14 +4,14 @@
     {
       "git": "github",
       "ci": "tekton",
-      "registry": "quay.io",
+      "registry": "quay",
       "tpa": "remote",
       "acs": "local"
     },
     {
       "git": "gitlab",
       "ci": "tekton",
-      "registry": "quay.io",
+      "registry": "quay",
       "tpa": "remote",
       "acs": "local"
     }


### PR DESCRIPTION
In reference to https://github.com/redhat-appstudio/rhtap-cli/pull/1029, removing quay specific automation configuration to be in sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated examples and descriptions to use "quay" instead of "quay.io" as the image registry in all documentation and sample configurations.
  * Revised the list of valid registry values in documentation.

* **Chores**
  * Updated configuration files to replace "quay.io" with "quay" for registry values.

* **Refactor**
  * Removed support for "quay.io" as a registry value in internal registry handling, consolidating to "quay".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->