### PR TITLE
feat: Add CI provider UI verification test

### DIFF
--- a/src/rhtap/core/integration/registry/imageRegistry.ts
+++ b/src/rhtap/core/integration/registry/imageRegistry.ts
@@ -2,6 +2,7 @@ import { KubeClient } from './../../../../../src/api/ocp/kubeClient';
 
 export enum ImageRegistryType {
   QUAY = 'quay',
+  QUAY_IO = 'quay.io',
   ARTIFACTORY = 'artifactory',
   NEXUS = 'nexus',
 }

--- a/src/rhtap/core/integration/registry/registryFactory.ts
+++ b/src/rhtap/core/integration/registry/registryFactory.ts
@@ -51,6 +51,7 @@ export class RegistryFactory {
     let imageOrg;
     switch (imageRegistryType) {
       case ImageRegistryType.QUAY:
+      case ImageRegistryType.QUAY_IO:
         imageOrg = loadFromEnv('QUAY_REGISTRY_ORG');
         const quayRegistry = new QuayRegistry(imageOrg, imageName);
         quayRegistry.setKubeClient(this.kubeClient);

--- a/tests/ui/ui.test.ts
+++ b/tests/ui/ui.test.ts
@@ -57,4 +57,15 @@ test.describe('RHTAP UI Test Suite', () => {
       await component.getGit().checkViewSourceLink(page);
     });
   });
+
+  test.describe("Verify CI", () => {
+    test('verify Tekton CI provider on CI tab', async ({ page }) => {
+      const componentUrl = component.getComponentUrl();
+      const ciTabUrl = `${componentUrl}/ci`;
+      await page.goto(ciTabUrl, { timeout: 20000 });
+        
+      await page.waitForLoadState('domcontentloaded');
+      await page.getByRole('heading', { name: component.getCoreComponent().getName() }).waitFor({ state: 'visible', timeout: 20000 });
+    });
+  });
 }); 


### PR DESCRIPTION
- Add UI test to verify CI provider displays component name correctly
- Add QUAY_IO registry type to ImageRegistryType enum
- Update RegistryFactory to handle both QUAY and QUAY_IO cases

Fixes RHTAPUI-53