### PR TITLE
Increase maxRetries from 50 seconds to 120 for component creation in RHDH

### DIFF
--- a/src/api/rhdh/developerhub.ts
+++ b/src/api/rhdh/developerhub.ts
@@ -154,14 +154,14 @@ export class DeveloperHub {
       }
     };
 
-    const maxRetries = 10; // Maximum number of retries (increased from 20)
+    const maxRetries = 24; // Maximum number of retries
+    const timeout = 5000;
 
     try {
       await retry(checkComponentStatus, {
         retries: maxRetries,
-        minTimeout: 5000, // Start with 5 seconds between retries (up from 5)
-        maxTimeout: 5000, // Maximum 5 seconds between retries
-        factor: 1.5, // Exponential backoff factor
+        minTimeout: timeout,
+        maxTimeout: timeout,
         onRetry: (error: Error, attempt: number) => {
           console.log(
             `[RETRY ${attempt}/${maxRetries}] 🔄 Task: ${taskId} | Reason: ${error.message}`


### PR DESCRIPTION
[This test run](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-shared-team-tenant/applications/tssc-test/pipelineruns/e2e-4.18-5wzpj) failed on  
```
1) [e2e-go[github-tekton-quay]] › tests/tssc/full_workflow.test.ts:40:5 › TSSC Complete Workflow › Component Creation › should create a component successfully 

    Error: Component creation timed out: Component creation still in progress (status: processing)

       at ../src/api/rhdh/developerhub.ts:185

      183 |           `Failed to check component status after ${maxRetries} retries: ${errorMessage}`
      184 |         );
    > 185 |         throw new Error(`Component creation timed out: ${errorMessage}`);
          |               ^
      186 |       }
      187 |     }
      188 |   }
        at DeveloperHub.waitUntilComponentIsCompleted (/e2e-test/src/api/rhdh/developerhub.ts:185:15)
        at Component.waitUntilComponentIsCompleted (/e2e-test/src/rhtap/core/component.ts:115:5)
        at /e2e-test/tests/tssc/full_workflow.test.ts:50:7
```

Looking at backstage logs for that run https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com/rhtap-cli/e2e-4.18-5wzpj/cluster-artifacts/pods/ I see that specific scaffolder task (bfbaa9f5-b6a2-4d8f-9946-1f2c6ec6cde7) took more than 50 seconds, which is the timeout right now:
First occurence of the task in backstage logs has timestamp `2025-08-06 12:43:44` and last occurence has `2025-08-06 12:44:40`

I believe increasing the timeout to 2 minutes from 50 seconds should be enough

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when waiting for components to complete by using consistent 5-second retry intervals.
  * Increased retry attempts from 10 to 24 to reduce premature failures and improve stability.
  * Made retry timing more predictable, reducing intermittent timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->