### PR TITLE
Add 4.19 to rhads-config

### DIFF
--- a/integration-tests/config/rhads-config
+++ b/integration-tests/config/rhads-config
@@ -1,4 +1,4 @@
-OCP="4.18"
+OCP="4.19"
 ACS="remote"
 REGISTRY="quay,artifactory,nexus"
 TPA="remote"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Platform baseline updated from OCP 4.18 to OCP 4.19.
  * Integration tests and related workflows now target the newer OCP baseline to align with current platform versions and reduce environment drift.
  * No other configuration values changed; low-risk update with no user-facing behavior alterations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->