### PR TITLE
run ssc on supported ocp versions

### DIFF
--- a/integration-tests/config/rhads-config
+++ b/integration-tests/config/rhads-config
@@ -1,4 +1,4 @@
-OCP="4.18"
+OCP="4.19"
 ACS="remote"
 REGISTRY="quay,artifactory,nexus"
 TPA="remote"


### PR DESCRIPTION
RHADS-SSC support OCP 4.17-4.19

