### PR TITLE
Remove GitLab CI and Bitbucket from suite

### DIFF
--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -22,13 +22,6 @@
     "acs": "remote"
   },
   {
-    "git": "gitlab",
-    "ci": "gitlabci",
-    "registry": "quay",
-    "tpa": "remote",
-    "acs": "remote"
-  },
-  {
     "git": "github",
     "ci": "jenkins",
     "registry": "quay",

--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -27,13 +27,6 @@
     "registry": "quay",
     "tpa": "remote",
     "acs": "remote"
-  },
-  {
-    "git": "bitbucket",
-    "ci": "tekton",
-    "registry": "quay",
-    "tpa": "remote",
-    "acs": "remote"
   }],
   "tests": ["test1", "test2"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed two integration test scenarios (GitLab-based and a Bitbucket/Tekton scenario).
  * All other test scenarios remain; test execution and coverage for remaining configurations are unchanged.

* **Chores**
  * Cleaned up obsolete test configurations to streamline maintenance and reduce test plan complexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->