### PR TITLE
Increase default timeout in GithubActionsService to 155 seconds.

### DIFF
--- a/src/api/github/services/github-actions.service.ts
+++ b/src/api/github/services/github-actions.service.ts
@@ -38,9 +38,10 @@ export class GithubActionsService {
 
   constructor(octokit: Octokit, config: GithubActionsServiceConfig = {}) {
     this.octokit = octokit;
+    // Default values. This should correspond to 155 seconds in 5 retries(5, 10, 20, 40, 80 seconds)
     this.maxRetries = config.maxRetries ?? 5;
     this.minTimeout = config.minTimeout ?? 5000;
-    this.maxTimeout = config.maxTimeout ?? 10000;
+    this.maxTimeout = config.maxTimeout ?? 80000;
     this.factor = config.factor ?? 2;
     this.defaultResultsPerPage = config.defaultResultsPerPage ?? 100;
   }


### PR DESCRIPTION
To prevent failures like https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-shared-team-tenant/applications/tssc-cli/taskruns/e2e-4.18-vzpkh-tssc-e2e-tests/logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced intermittent failures when communicating with GitHub by increasing the default request timeout and aligning the retry backoff sequence.
  * Improves reliability during slow or high-latency responses, resulting in fewer timeout errors and more stable runs.
  * Users may notice fewer retried operations failing during peak load thanks to a longer allowed wait and consistent backoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->