### PR TITLE
RHTAP-5377 - Do not redirect err&std to /dev/null for debugging purposes.

### DIFF
--- a/integration-tests/tasks/tssc-e2e.yaml
+++ b/integration-tests/tasks/tssc-e2e.yaml
@@ -209,7 +209,7 @@ spec:
                 --password="$OCI_STORAGE_TOKEN" \
                 --annotation-file "$ANNOTATION_FILE" \
                 playwright-report/:application/vnd.acme.rocket.docs.layer.v1+tar \
-                tmp/test-items.json/:application/json >/dev/null 2>&1; then
+                tmp/test-items.json/:application/json; then
               echo "Test results uploaded successfully"
               return 0
             fi


### PR DESCRIPTION
Lately I've seen lot of failures in this part of the pipeline. It could help to have the output of `oras push`.
Example: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-shared-team-tenant/applications/tssc-test/pipelineruns/e2e-4.18-f8q5z