### PR TITLE
[RHTAPUI-106] Implements workaround for testing Kubernetes/Docs page

### DIFF
--- a/src/ui/common.ts
+++ b/src/ui/common.ts
@@ -14,3 +14,26 @@ export async function checkWebsiteStatus(
     const response = await page.request.head(href);
     expect(okStatuses).toContain(response.status());
 }
+
+/**
+ * Hides the Quick start side panel if it is visible
+ * @param page - The Playwright page object
+ */
+export async function hideQuickStartIfVisible(page: Page): Promise<void> {
+    // Wait for the page to be loaded by checking the self service icon
+    const selfServiceIcon = page.getByTestId('AddCircleOutlineIcon');
+    await selfServiceIcon.waitFor({ state: 'visible', timeout: 20000 });
+
+    // Wait for welcome paragraph to be visible 
+    const welcomeParagraph = page.getByText("Let's get you started with Developer Hub", { exact: true });
+    const hideButton = page.getByRole('button', { name: 'Hide' });
+    try {
+      await welcomeParagraph.waitFor({ state: 'visible', timeout: 2000 });
+      await hideButton.click({ timeout: 2000 });
+      console.log('Paragraph visible; hiding Quick start side panel');
+    } catch {
+      console.log('Paragraph not visible; skipping hide');
+    }
+
+    await expect(welcomeParagraph).toBeHidden({ timeout: 10000 });
+  }

--- a/tests/ui/ui.test.ts
+++ b/tests/ui/ui.test.ts
@@ -1,6 +1,7 @@
 import { createBasicFixture } from '../../src/utils/test/fixtures';
 import { UiComponent } from '../../src/ui/uiComponent';
 import { CommonPO } from '../../src/ui/page-objects/common_po';
+import { hideQuickStartIfVisible } from '../../src/ui/common';
 
 /**
  * Create a basic test fixture with testItem
@@ -83,6 +84,12 @@ test.describe('RHTAP UI Test Suite', () => {
         timeout: 20000,
       });
 
+      // Hide Quick start side panel
+      // WORKAROUND FOR: https://issues.redhat.com/browse/RHDHBUGS-1946
+      await test.step('Hide Quick start side panel', async () => {
+        await hideQuickStartIfVisible(page);
+      }, { timeout: 20000 });
+
       await test.step('Check article display', async () => { 
         await docsPlugin.checkArticle(page);
       }, {timeout: 60000});
@@ -100,7 +107,7 @@ test.describe('RHTAP UI Test Suite', () => {
       }, {timeout: 20000});
     });
   });
-  
+
   test.describe('Test Image Registry', () => {
     test('test image registry', async ({ page }) => {
       const registryPlugin = component.getRegistry();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved UI test stability by automatically hiding the Quick Start side panel during the docs flow when present.
  * Added resilient handling and appropriate timeouts to avoid false failures if the panel doesn’t appear.
  * Ensures the panel remains hidden before proceeding, reducing flakiness and improving reliability of the docs verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->