### PR TITLE
[ci-test-fix] Excludes githubactions from UI tests

### DIFF
--- a/tests/ui/ui.test.ts
+++ b/tests/ui/ui.test.ts
@@ -2,6 +2,7 @@ import { createBasicFixture } from '../../src/utils/test/fixtures';
 import { UiComponent } from '../../src/ui/uiComponent';
 import { CommonPO } from '../../src/ui/page-objects/common_po';
 import { hideQuickStartIfVisible } from '../../src/ui/common';
+import { CIType } from '../../src/rhtap/core/integration/ci';
 
 /**
  * Create a basic test fixture with testItem
@@ -66,10 +67,16 @@ test.describe('RHTAP UI Test Suite', () => {
   
   test.describe("Verify CI", () => {
     test('verify CI provider on CI tab', async ({ page }) => {
+      if (component.getCoreComponent().getCI().getCIType() === CIType.GITHUB_ACTIONS) {
+        console.warn(`Skipping CI test as testing ${component.getCoreComponent().getCI().getCIType} is not supported`);
+        test.skip();
+        return;
+      }
+
       const componentUrl = component.getComponentUrl();
       const ciTabUrl = `${componentUrl}/ci`;
       await page.goto(ciTabUrl, { timeout: 20000 });
-        
+
       await page.waitForLoadState('domcontentloaded');
       await page.getByRole('heading', { name: component.getCoreComponent().getName() }).waitFor({ state: 'visible', timeout: 20000 });
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the UI CI tab test to conditionally skip when running under GitHub Actions, reducing flaky test runs in that environment.
  * Maintains the existing CI tab navigation and verification flow when the skip condition is not met.
  * Applied minor formatting adjustments within the test block.
  * No user-facing behavior changes; this improves CI stability and reliability during automated test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->