### PR TITLE
Remove bitbucket as git provider

### DIFF
--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -22,13 +22,6 @@
     "acs": "remote"
   },
   {
-    "git": "bitbucket",
-    "ci": "tekton",
-    "registry": "quay",
-    "tpa": "remote",
-    "acs": "remote"
-  },
-  {
     "git": "github",
     "ci": "jenkins",
     "registry": "quay",


### PR DESCRIPTION
Remove Bitbucket as git provider from testplan.json because Bitbucket support API token only. When Installer supports it, we will add it back

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test plan by removing one scenario involving Bitbucket with Tekton and Quay in a remote setup.
  * Streamlines the test matrix while keeping all other scenarios intact.
  * No impact on product functionality or user workflows; remaining tests continue to validate supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->