### PR TITLE
[azure-set-var-fix] Change default Azure pool name and var group to regexes

### DIFF
--- a/src/rhtap/modification/contentModification.ts
+++ b/src/rhtap/modification/contentModification.ts
@@ -2,7 +2,7 @@
  * Represents a single content modification for a file
  */
 export interface ContentModification {
-  oldContent: string;
+  oldContent: string | RegExp;
   newContent: string;
 }
 
@@ -26,7 +26,7 @@ export class ContentModificationsContainer {
    */
   public add(
     filePath: string,
-    oldContent: string,
+    oldContent: string | RegExp,
     newContent: string
   ): ContentModificationsContainer {
     if (!this.modifications[filePath]) {

--- a/src/rhtap/postcreation/strategies/commands/modifyAzureFiles.ts
+++ b/src/rhtap/postcreation/strategies/commands/modifyAzureFiles.ts
@@ -1,5 +1,6 @@
 import { Component } from '../../../core/component';
-import { ContentModifications, Git } from '../../../core/integration/git';
+import { Git } from '../../../core/integration/git';
+import { ContentModifications } from '../../../modification/contentModification';
 import { BaseCommand } from './baseCommand';
 
 const COMMIT_MESSAGE = 'Update Azure Pipeline agent pool and variable group';
@@ -28,11 +29,11 @@ export class ModifyAzureFiles extends BaseCommand {
     const modifications: ContentModifications = {
       'azure-pipelines.yml': [
         {
-          oldContent: 'name: Default',
+          oldContent: /name: \w+/,
           newContent: `name: ${AGENT_POOL}`,
         },
         {
-          oldContent: '- group: rhtap',
+          oldContent: /- group: \w+/,
           newContent: `- group: ${this.component.getName()}`,
         },
       ],


### PR DESCRIPTION
Related slack discussion: https://redhat-internal.slack.com/archives/C065GQMTLN4/p1759316411481109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for pattern-based (regex) content matching when applying file modifications.
- Improvements
  - More reliable updates to Azure Pipelines configuration, handling varying names and groups without manual edits.
- Refactor
  - Internal module organization updated to streamline modification handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->