### PR TITLE
[RHTAP-5676] Verify Gitlab

### DIFF
--- a/src/ui/plugins/git/gitUi.ts
+++ b/src/ui/plugins/git/gitUi.ts
@@ -1,0 +1,28 @@
+import { expect, Locator, Page } from '@playwright/test';
+import { Git } from '../../../rhtap/core/integration/git';
+
+export class GitUi {
+    private gitProvider: Git;
+
+    constructor(
+        git: Git
+    ) {
+        this.gitProvider = git;
+    }
+
+    protected async checkGitLink(page: Page, gitLink: Locator): Promise<void> {
+        await expect(gitLink).toBeVisible();
+
+        const linkHref = await gitLink.getAttribute('href');
+        expect(gitLink).toBeTruthy();
+
+        const isClickable = await gitLink.isEnabled();
+        expect(isClickable).toBe(true);
+
+        const response = await page.request.head(linkHref!);
+        const status = response.status();
+        expect(status).not.toBe(404);
+
+        console.log(`Checked git link: ${linkHref}`);
+    }
+}

--- a/src/ui/plugins/git/gitUiFactory.ts
+++ b/src/ui/plugins/git/gitUiFactory.ts
@@ -7,6 +7,7 @@
 
 import { Git, GitType } from '../../../rhtap/core/integration/git/gitInterface';
 import { GithubUiPlugin } from './githubUi';
+import { GitlabUiPlugin } from './gitlabUi';
 import { GitPlugin } from './gitUiInterface';
 
 export class GitUiFactory {
@@ -25,6 +26,8 @@ export class GitUiFactory {
         switch (gitType) {
             case GitType.GITHUB:
                 return new GithubUiPlugin(git);
+            case GitType.GITLAB:
+                return new GitlabUiPlugin(git);
             default:
                 console.warn(`Unsupported Git type: ${gitType}`);
                 return undefined;

--- a/src/ui/plugins/git/gitUiInterface.ts
+++ b/src/ui/plugins/git/gitUiInterface.ts
@@ -1,6 +1,17 @@
 import { Page } from "@playwright/test";
 
 export interface GitPlugin {
+    /**
+     * Performs Git login through the Developer Hub UI.
+     * 
+     * @param page - Playwright Page object for UI interactions
+     */
     login(page: Page): Promise<void>;
+
+    /**
+     * Verifies the Git "View Source" link on the component page.
+     * 
+     * @param page - Playwright Page object for UI interactions
+     */
     checkViewSourceLink(page: Page): Promise<void>;
 }

--- a/src/ui/plugins/git/githubUi.ts
+++ b/src/ui/plugins/git/githubUi.ts
@@ -10,18 +10,11 @@ import { expect, Page } from '@playwright/test';
 import { loadFromEnv } from '../../../utils/util';
 import { DHLoginPO, GhLoginPO } from '../../page-objects/loginPo';
 import { GitPO } from '../../page-objects/commonPo';
-import { Git } from '../../../rhtap/core/integration/git/gitInterface';
 import { authenticator } from 'otplib';
 import retry from 'async-retry';
+import { GitUi } from './gitUi';
 
-export class GithubUiPlugin implements GitPlugin {
-    private githubProvider: Git;
-
-    constructor(
-        git: Git
-    ) {
-        this.githubProvider = git
-    }
+export class GithubUiPlugin extends GitUi implements GitPlugin {
 
     /**
      * Performs GitHub login through the Developer Hub UI.
@@ -86,27 +79,9 @@ export class GithubUiPlugin implements GitPlugin {
         }
     }
 
-    /**
-     * Verifies the GitHub "View Source" link on the component page.
-     * Checks that the link is visible, clickable, and accessible.
-     *
-     * @param page - Playwright Page object for UI interactions
-     */
     async checkViewSourceLink(page: Page): Promise<void> {
         const githubLink = page.locator(`${GitPO.githubLinkSelector}:has-text("${GitPO.viewSourceLinkText}")`);
-        await expect(githubLink).toBeVisible({ timeout: 10000 });
-
-        const linkHref = await githubLink.getAttribute('href');
-        expect(githubLink).toBeTruthy();
-
-        const isClickable = await githubLink.isEnabled();
-        expect(isClickable).toBe(true);
-
-        const response = await page.request.head(linkHref!);
-        const status = response.status();
-        expect(status).toBe(200);
-
-        console.log(`GitHub URL: ${linkHref}`);
+        await super.checkGitLink(page, githubLink);
     }
 
     /**

--- a/src/ui/plugins/git/gitlabUi.ts
+++ b/src/ui/plugins/git/gitlabUi.ts
@@ -6,28 +6,19 @@
  */
 
 import { GitPlugin } from './gitUiInterface';
-import { Git } from '../../../rhtap/core/integration/git';
 import { Page } from '@playwright/test';
+import { GitUi } from './gitUi';
+import { GitPO } from '../../page-objects/commonPo';
 
-export class GitlabUiPlugin implements GitPlugin {
-    private gitlabProvider: Git;
-
-    constructor(
-        git: Git
-    ) {
-        this.gitlabProvider = git;
-    }
-
-    /**
-     * Performs GitLab login through the Developer Hub UI.
-     * Currently not implemented - placeholder for future implementation.
-     * 
-     * @param page - Playwright Page object for UI interactions
-     * @throws Error indicating method is not implemented
-     */
+export class GitlabUiPlugin extends GitUi implements GitPlugin  {
     async login(page: Page): Promise<void> {
         // Implement GitLab-specific login logic using page objects
         // This would typically involve OAuth flow or token-based authentication
         throw new Error('Method not implemented.');
+    }
+
+    async checkViewSourceLink(page: Page): Promise<void> {
+        const gitlabLink = page.locator(`${GitPO.gitlabLinkSelector}:has-text("${GitPO.viewSourceLinkText}")`);
+        await this.checkGitLink(page, gitlabLink);
     }
 }

--- a/tests/ui/component.test.ts
+++ b/tests/ui/component.test.ts
@@ -58,7 +58,9 @@ test.describe('Component UI Test Suite', () => {
       await page.goto(component.getComponentUrl(), { timeout: 20000 });
       await waitForPageLoad(page, component.getCoreComponent().getName());
 
-      await component.getGit()!.checkViewSourceLink(page);
+      await test.step('Check Git Source link', async () => {
+        await component.getGit()!.checkViewSourceLink(page);
+      }, { timeout: 20000 });
     });
   });
 


### PR DESCRIPTION
This PR adds check for Gitlab source link.

Issue:  [RHTAP-5676](https://issues.redhat.com/browse/RHTAP-5676)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added GitLab support for verifying “View Source” links in the UI.
  * Introduced a reusable Git UI helper for consistent link checks (visibility, enabled state, and 404 validation).

* Refactor
  * Consolidated Git UI logic into a shared base used by GitHub and GitLab plugins for simpler, aligned behavior.

* Documentation
  * Added inline docs for login and source-link verification methods.

* Tests
  * Wrapped source link verification in a named test step with a timeout for clearer reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->