### PR TITLE
RHTAP-5722: Fix getting runner image value for multi-ci testing

### DIFF
--- a/src/rhtap/core/integration/ci/providers/azureCI.ts
+++ b/src/rhtap/core/integration/ci/providers/azureCI.ts
@@ -278,6 +278,10 @@ export class AzureCI extends BaseCI {
     return this.mapAzureStatusToPipelineStatus(pipelineRun);
   }
 
+  public override async getCIFilePathInRepo(): Promise<string> {
+    return 'azure-pipelines.yml';
+  }
+
   public async waitForAllPipelineRunsToFinish(): Promise<void> {
     await retry(
       async () => {

--- a/src/rhtap/postcreation/strategies/azureCIPostCreateActionStrategy.ts
+++ b/src/rhtap/postcreation/strategies/azureCIPostCreateActionStrategy.ts
@@ -4,6 +4,7 @@ import { AddAzureVarsAndSecrets } from './commands/addAzureSecrets';
 import { AuthorizeAzurePipelines } from './commands/authorizeAzurePipeline';
 import { CreateAzurePipelines } from './commands/createAzurePipelines';
 import { ModifyAzureFiles } from './commands/modifyAzureFiles';
+import { UpdateCIRunnerImage } from './commands/updateCIRunnerImage';
 import { ComponentActionStrategy } from '../../common/strategies/componentActionStrategy';
 
 /**
@@ -28,6 +29,7 @@ export class AzureCIPostCreateActionStrategy implements ComponentActionStrategy 
         new ModifyAzureFiles(component),
         new CreateAzurePipelines(component),
         new AuthorizeAzurePipelines(component),
+        new UpdateCIRunnerImage(component),
       ];
 
       for (const command of commands) {

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -222,18 +222,20 @@ export function base64Decode(base64Str: string, isUrlSafe: boolean = false): str
 
 /**
  * Gets existing Runner Image value from CI File content
+ * Matches specific runner image patterns starting with quay.io or registry.access.redhat.com
  * @param fileContent file content string
  * @returns runner image value
  */
 export function getRunnerImageFromCIFile(fileContent: string): string {
-  const pattern = /^\s*image:\s*(.*)$/gm;
+  // Pattern to match runner images starting with specific registries anywhere in content
+  const pattern = /((?:quay\.io|registry\.access\.redhat\.com)\/[a-zA-Z0-9._/-]+:[a-zA-Z0-9._-]+)/g
   const match = pattern.exec(fileContent);
 
   if (!match) {
     throw new Error(`Runner image not found in the CI file content`);
   }
 
-  // Get group value after "image:" pattern if match found
+  // Get the matched image value directly
   const oldImageValue = match[1];
   console.log(`Old Image Value: ${oldImageValue}`);
   return oldImageValue;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Azure CI support by recognizing the default pipeline configuration file.
  * Added automated update of the CI runner image during post-creation actions for Azure CI.

* **Bug Fixes**
  * Improved detection of runner images in CI files by matching image references from common registries (e.g., quay.io, registry.access.redhat.com) anywhere in the file, increasing compatibility with varied formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->