### PR TITLE
RHTAP-5692 Add multiple test plans

### DIFF
--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -1,46 +1,51 @@
 {
-  "templates": ["go"],
-  "tssc": [{
-    "git": "github",
-    "ci": "tekton",
-    "registry": "quay",
-    "tpa": "remote",
-    "acs": "remote"
-  },
-  {
-    "git": "gitlab",
-    "ci": "tekton",
-    "registry": "nexus",
-    "tpa": "remote",
-    "acs": "remote"
-  },
-  {
-    "git": "gitlab",
-    "ci": "gitlabci",
-    "registry": "quay",
-    "tpa": "remote",
-    "acs": "remote"
-  },
-  {
-    "git": "github",
-    "ci": "githubactions",
-    "registry": "artifactory",
-    "tpa": "remote",
-    "acs": "remote"
-  },
-  {
-    "git": "bitbucket",
-    "ci": "tekton",
-    "registry": "quay",
-    "tpa": "remote",
-    "acs": "remote"
-  },
-  {
-    "git": "github",
-    "ci": "azure",
-    "registry": "quay",
-    "tpa": "remote",
-    "acs": "remote"
-  }],
-  "tests": ["full_workflow.test.ts"]
+"testPlans": [
+    {
+      "name": "backend-tests",
+      "templates": ["go"],
+      "tssc": [{
+        "git": "github",
+        "ci": "tekton",
+        "registry": "quay",
+        "tpa": "remote",
+        "acs": "remote"
+      },
+      {
+        "git": "gitlab",
+        "ci": "tekton",
+        "registry": "nexus",
+        "tpa": "remote",
+        "acs": "remote"
+      },
+      {
+        "git": "gitlab",
+        "ci": "gitlabci",
+        "registry": "quay",
+        "tpa": "remote",
+        "acs": "remote"
+      },
+      {
+        "git": "github",
+        "ci": "githubactions",
+        "registry": "artifactory",
+        "tpa": "remote",
+        "acs": "remote"
+      },
+      {
+        "git": "bitbucket",
+        "ci": "tekton",
+        "registry": "quay",
+        "tpa": "remote",
+        "acs": "remote"
+      },
+      {
+        "git": "github",
+        "ci": "azure",
+        "registry": "quay",
+        "tpa": "remote",
+        "acs": "remote"
+      }],
+      "tests": ["full_workflow.test.ts"]
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
         "validate": "npm run type-check && npm run lint && npm run format:check",
         "generate-config": "npx ts-node scripts/generateProjectConfig.ts",
         "test": "npm run generate-config && playwright test",
-        "test:e2e": "npm run generate-config && ENABLE_E2E_TESTS=true ENABLE_UI_TESTS=false playwright test",
-        "test:ui": "ENABLE_E2E_TESTS=false ENABLE_UI_TESTS=true playwright test",
-        "test:ui-interactive": "ENABLE_E2E_TESTS=false ENABLE_UI_TESTS=true playwright test --ui",
-        "test:all": "npm run generate-config && ENABLE_E2E_TESTS=true ENABLE_UI_TESTS=true playwright test",
+        "test:e2e": "TESTPLAN_NAME=backend-tests npm run generate-config &&  playwright test",
+        "test:ui": "TESTPLAN_NAME=ui-tests playwright test",
+        "test:ui-interactive": "TESTPLAN_NAME=ui-tests playwright test --ui",
+        "test:all": "TESTPLAN_NAME=backend-tests npm run generate-config &&  playwright test && TESTPLAN_NAME=ui-tests playwright test",
         "test:report": "playwright show-report"
     },
     "keywords": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig} from '@playwright/test';
 import { TestItem } from './src/playwright/testItem';
 import { loadProjectConfigurations, ProjectConfig } from './src/utils/projectConfigLoader';
 import { getTestMatchPattern } from './src/utils/testFilterLoader';
+import { TestPlan } from './src/playwright/testplan';
 import path from 'path';
 
 // Extend Playwright types to include testItem
@@ -15,8 +16,6 @@ declare module '@playwright/test' {
 const DEFAULT_TIMEOUT = 2100000; // 35 minutes
 
 // Environment variable flags to control which tests run
-const ENABLE_E2E_TESTS = process.env.ENABLE_E2E_TESTS !== 'false'; // Default: true
-const ENABLE_UI_TESTS = process.env.ENABLE_UI_TESTS === 'true';    // Default: false
 const DEFAULT_WORKERS = 6;
 const DEFAULT_UI_TIMEOUT = 60000;
 
@@ -30,50 +29,156 @@ try {
   // Authentication file path
   const authFile = path.join('./playwright/.auth/user.json');
 
+  // Detect if UI tests are needed based on test plan content
+  let hasUITests = false;
+  const requestedPlan = process.env.TESTPLAN_NAME;
+  
+  // Special handling for ui-tests plan
+  if (requestedPlan === 'ui-tests') {
+    hasUITests = true;
+    console.log('Running UI tests with existing project configuration');
+  } else {
+    const testPlanPath = process.env.TESTPLAN_PATH || path.resolve(process.cwd(), 'testplan.json');
+    console.log(`Checking for UI tests in test plan: ${testPlanPath}`);
+    
+    // Check if test plan file exists first
+    if (!require('fs').existsSync(testPlanPath)) {
+      console.warn(`Test plan file not found at ${testPlanPath}, defaulting to E2E tests`);
+    } else {
+      try {
+        const testPlanData = JSON.parse(require('fs').readFileSync(testPlanPath, 'utf-8'));
+        const testPlan = new TestPlan(testPlanData);
+        
+        // Check if any test plan contains UI-related tests
+        // Uses naming convention: tests containing 'ui', 'component', or 'page' substrings are considered UI tests
+        const allTests = testPlan.getTests();
+        hasUITests = allTests.some(test => 
+          test.toLowerCase().includes('ui') || 
+          test.toLowerCase().includes('component') ||
+          test.toLowerCase().includes('page')
+        );
+        console.log(`UI test detection completed for ${testPlanPath}: ${hasUITests ? 'UI tests found' : 'No UI tests detected'}`);
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          console.error(`Failed to parse JSON from test plan file ${testPlanPath}:`, error.message);
+          if (error instanceof Error) {
+            console.error('JSON parse error stack:', error.stack);
+          } else {
+            console.error('JSON parse error stack: <unknown error type>');
+          }
+        } else if (error instanceof Error) {
+          console.error(`IO error reading test plan file ${testPlanPath}:`, error.message);
+          console.error('IO error stack:', error.stack);
+        } else {
+          console.error(`IO error reading test plan file ${testPlanPath}: <unknown error>`);
+          console.error('IO error stack: <unknown error type>');
+        }
+        console.warn('Defaulting to E2E tests due to test plan parsing error');
+      }
+    }
+  }
+
+  // Determine if UI tests should run based on test plan content
+  const shouldRunUITests = hasUITests;
+
   let e2eProjects: any[] = [];
   let uiProjects: any[] = [];
   let authProjects: any[] = [];
 
-  // Create e2e projects if enabled
-  if (ENABLE_E2E_TESTS) {
-    const testMatchPattern = getTestMatchPattern();
+  // Create E2E projects (always created for backend tests)
+  let testMatchPattern: string;
+  let patterns: string[];
+  
+  // Special handling for ui-tests plan - use UI-specific patterns
+  if (requestedPlan === 'ui-tests') {
+    patterns = ['**/*.ui.test.ts', '**/*.ui.test.tsx', '**/ui/**/*.test.ts', '**/ui/**/*.test.tsx'];
+    console.log('Using UI-specific test patterns for ui-tests plan');
+  } else {
+    testMatchPattern = getTestMatchPattern();
+    
+    // Parse test match pattern - handle both string and array formats
+    if (Array.isArray(testMatchPattern)) {
+      patterns = testMatchPattern;
+    } else if (typeof testMatchPattern === 'string') {
+      // Handle curly brace format like "{pattern1,pattern2}"
+      if (testMatchPattern.startsWith('{') && testMatchPattern.endsWith('}')) {
+        const content = testMatchPattern.slice(1, -1);
+        patterns = content.split(',').map(p => p.trim());
+      } else {
+        patterns = [testMatchPattern];
+      }
+    } else {
+      patterns = ['**/*.test.ts'];
+    }
+  }
+  
+  // Filter tests to separate E2E and UI tests
+  // Use case-insensitive filtering to match UI detection logic
+  let e2eTests = patterns.filter(pattern => {
+    const lowerPattern = pattern.toLowerCase();
+    return !lowerPattern.includes('ui') && !lowerPattern.includes('component') && !lowerPattern.includes('page');
+  });
+  let uiTests = patterns.filter(pattern => {
+    const lowerPattern = pattern.toLowerCase();
+    return lowerPattern.includes('ui') || lowerPattern.includes('component') || lowerPattern.includes('page');
+  });
+
+  // If shouldRunUITests is true but no UI patterns were detected, add default UI patterns
+  if (shouldRunUITests && uiTests.length === 0) {
+    uiTests = ['**/*.ui.test.ts', '**/*.ui.test.tsx', '**/ui/**/*.test.ts', '**/ui/**/*.test.tsx'];
+  }
+
+  // Create projects based on test types
+  if (e2eTests.length > 0 && uiTests.length === 0) {
+    // Only E2E tests - create E2E projects
     e2eProjects = projectConfigs.map(config => ({
       name: `e2e-${config.name}`,
-      testMatch: testMatchPattern,
+      testMatch: e2eTests,
       use: {
         testItem: config.testItem,
       },
     }));
-  }
-
-  // Create UI projects if enabled
-  if (ENABLE_UI_TESTS) {
-    // Create auth setup project for UI tests
+  } else if (e2eTests.length === 0 && uiTests.length > 0) {
+    // Only UI tests - create UI projects with auth setup
     authProjects = [{ name: 'auth-setup', testMatch: '**/auth.setup.ts' }];
-
-    const testMatchPattern = getTestMatchPattern();
     uiProjects = projectConfigs.map(config => ({
       name: `ui-${config.name}`,
-      testMatch: testMatchPattern,
+      testMatch: uiTests,
       use: {
         testItem: config.testItem,
         storageState: authFile,
       },
       expect: {
-          timeout: DEFAULT_UI_TIMEOUT,
-        },
+        timeout: DEFAULT_UI_TIMEOUT,
+      },
+      dependencies: ['auth-setup']
+    }));
+  } else if (e2eTests.length > 0 && uiTests.length > 0) {
+    // Mixed tests - create both E2E and UI projects
+    e2eProjects = projectConfigs.map(config => ({
+      name: `e2e-${config.name}`,
+      testMatch: e2eTests,
+      use: {
+        testItem: config.testItem,
+      },
+    }));
+    
+    authProjects = [{ name: 'auth-setup', testMatch: '**/auth.setup.ts' }];
+    uiProjects = projectConfigs.map(config => ({
+      name: `ui-${config.name}`,
+      testMatch: uiTests,
+      use: {
+        testItem: config.testItem,
+        storageState: authFile,
+      },
+      expect: {
+        timeout: DEFAULT_UI_TIMEOUT,
+      },
       dependencies: [
-        // Always depend on auth-setup
         'auth-setup',
-        ...(ENABLE_E2E_TESTS
-          // Set dependency behavior based on flag:
-          // By default, UI test depends only on its corresponding e2e test.
-          // If UI_DEPENDS_ON_ALL_E2E is set to 'true', depend on all e2e tests.
-          ? (process.env.UI_DEPENDS_ON_ALL_E2E === 'true'
-            ? projectConfigs.map(cfg => `e2e-${cfg.name}`)
-            : [`e2e-${config.name}`]
-            )
-          : []
+        ...(process.env.UI_DEPENDS_ON_ALL_E2E === 'true'
+          ? projectConfigs.map(cfg => `e2e-${cfg.name}`)
+          : [`e2e-${config.name}`]
         )
       ]
     }));

--- a/scripts/generateProjectConfig.ts
+++ b/scripts/generateProjectConfig.ts
@@ -17,6 +17,7 @@ function generateProjectConfig(): void {
   try {
     // Load test plan
     const testPlanPath = process.env.TESTPLAN_PATH || path.resolve(process.cwd(), 'testplan.json');
+    console.log(`Using test plan: ${testPlanPath}`);
     
     if (!existsSync(testPlanPath)) {
       throw new Error(`Test plan file not found: ${testPlanPath}`);
@@ -25,10 +26,45 @@ function generateProjectConfig(): void {
     const testPlanData = JSON.parse(readFileSync(testPlanPath, 'utf-8'));
     const testPlan = new TestPlan(testPlanData);
 
-    // Generate project configurations with consistent TestItems
-    const projectConfigs = testPlan.getProjectConfigs();
+    // Check if we have multiple test plans and if a specific plan is requested
+    const requestedPlan = process.env.TESTPLAN_NAME;
+    let projectConfigs: any[];
+    let requestedPlans: string[] = [];
+
+    if (requestedPlan && testPlan.getTestPlans().length > 0) {
+      // New format: filter by specific test plan(s) - support comma-separated values
+      requestedPlans = requestedPlan.split(',').map(name => name.trim()).filter(name => name.length > 0);
+      console.log(`Filtering test items for plan(s): ${requestedPlans.join(', ')}`);
+      
+      // Collect test items from all requested plans
+      const allTestItems: any[] = [];
+      for (const planName of requestedPlans) {
+        const testItems = testPlan.getTestItemsByPlanName(planName);
+        allTestItems.push(...testItems);
+      }
+      
+      projectConfigs = allTestItems.map(testItem => ({
+        name: `${testItem.getTemplate()}[${testItem.getGitType()}-${testItem.getCIType()}-${testItem.getRegistryType()}-${testItem.getACS()}]`,
+        testItem
+      }));
+    } else {
+      // Generate all project configurations (legacy behavior or all plans)
+      projectConfigs = testPlan.getProjectConfigs();
+    }
     
     console.log(`Generated ${projectConfigs.length} project configurations`);
+
+    // Log test plan information
+    if (testPlan.getTestPlans().length > 0) {
+      console.log(`Available test plans: ${testPlan.getTestPlanNames().join(', ')}`);
+      if (requestedPlan) {
+        console.log(`Using test plan: ${requestedPlan}`);
+      } else {
+        console.log('Using all test plans (no TESTPLAN_NAME specified)');
+      }
+    } else {
+      console.log('Using legacy single test plan format');
+    }
 
     // Prepare serialized configurations
     const serializedConfigs: ProjectConfig[] = projectConfigs.map(config => ({
@@ -51,10 +87,12 @@ function generateProjectConfig(): void {
       generatedAt: new Date().toISOString(),
       testPlanPath,
       totalConfigurations: projectConfigs.length,
+      requestedPlan: requestedPlan || 'all',
+      availableTestPlans: testPlan.getTestPlanNames(),
       testFiltering: {
-        tests: testPlan.getTests(),
-        testMatchPattern: testPlan.getTestMatchPattern(),
-        testMatchPatterns: testPlan.getTestMatchPatterns()
+        tests: requestedPlan ? testPlan.getTestsForPlans(requestedPlans) : testPlan.getTests(),
+        testMatchPattern: requestedPlan ? testPlan.getTestMatchPatternsForPlans(requestedPlans) : testPlan.getTestMatchPattern(),
+        testMatchPatterns: requestedPlan ? testPlan.getTestMatchPatternsForPlans(requestedPlans) : testPlan.getTestMatchPatterns()
       },
       testItems: projectConfigs.map(config => ({
         name: config.testItem.getName(),
@@ -68,8 +106,10 @@ function generateProjectConfig(): void {
     writeFileSync('./tmp/project-config-summary.json', JSON.stringify(summary, null, 2));
     
     // Log test filtering information
-    console.log(`Test filtering: ${testPlan.getTests().length > 0 ? testPlan.getTests().join(', ') : 'All tests'}`);
-    console.log(`Test match pattern: ${testPlan.getTestMatchPattern()}`);
+    const testsToShow = requestedPlan ? testPlan.getTestsForPlans(requestedPlans) : testPlan.getTests();
+    const testMatchPattern = requestedPlan ? testPlan.getTestMatchPatternsForPlans(requestedPlans) : testPlan.getTestMatchPattern();
+    console.log(`Test filtering: ${testsToShow.length > 0 ? testsToShow.join(', ') : 'All tests'}`);
+    console.log(`Test match pattern: ${testMatchPattern}`);
     console.log('Project configuration generation completed successfully!');
 
   } catch (error) {

--- a/src/playwright/testplan.ts
+++ b/src/playwright/testplan.ts
@@ -14,29 +14,87 @@ export interface TSScConfig {
   name?: string; // Optional name for deterministic TestItem naming
 }
 
-export class TestPlan {
+export interface TestPlanConfig {
+  name: string;
   templates: string[];
-  tsscConfigs: TSScConfig[];
+  tssc: TSScConfig[];
   tests: string[];
-  testItems: TestItem[]; // Regular field populated in constructor
+}
+
+export class TestPlan {
+  // Support for new multiple test plans format
+  testPlans?: TestPlanConfig[];
+  
+  // Support for legacy single test plan format (backward compatibility)
+  templates?: string[];
+  tsscConfigs?: TSScConfig[];
+  tests?: string[];
+  
+  // Combined test items from all test plans
+  testItems: TestItem[];
+  
+  // Map to track test items by plan name for efficient lookup
+  private testItemsByPlan: Map<string, TestItem[]> = new Map();
 
   constructor(data: any) {
-    this.templates = data.templates || [];
-    this.tsscConfigs = (data.tssc || []).map((config: any) => ({
-      git: config.git || '',
-      ci: config.ci || '',
-      registry: config.registry || '',
-      tpa: config.tpa || '',
-      acs: config.acs || '',
-      name: config.name, // Optional name from data
-    }));
-    this.tests = data.tests || [];
-
-    // Generate TestItems once in constructor
     this.testItems = [];
-    this.templates.forEach(template => {
-      this.tsscConfigs.forEach(tsscConfig => {
-        // Use provided name or generate random one
+    this.testItemsByPlan = new Map();
+
+    // Check if data has new format with testPlans array
+    if (data.testPlans && Array.isArray(data.testPlans)) {
+      // New format: multiple test plans
+      this.testPlans = data.testPlans;
+      this.processMultipleTestPlans();
+    } else {
+      // Legacy format: single test plan (backward compatibility)
+      this.templates = data.templates || [];
+      this.tsscConfigs = (data.tssc || []).map((config: any) => ({
+        git: config.git || '',
+        ci: config.ci || '',
+        registry: config.registry || '',
+        tpa: config.tpa || '',
+        acs: config.acs || '',
+        name: config.name,
+      }));
+      this.tests = data.tests || [];
+      this.processLegacyTestPlan();
+    }
+  }
+
+  private processMultipleTestPlans(): void {
+    this.testPlans?.forEach(testPlan => {
+      // Initialize the plan's test items array
+      this.testItemsByPlan.set(testPlan.name, []);
+      
+      testPlan.templates.forEach(template => {
+        testPlan.tssc.forEach(tsscConfig => {
+          const itemName = tsscConfig.name || `${testPlan.name}-${template}-${randomString()}`;
+          
+          const testItem = new TestItem(
+            itemName,
+            template as TemplateType,
+            tsscConfig.registry,
+            tsscConfig.git,
+            tsscConfig.ci,
+            tsscConfig.tpa,
+            tsscConfig.acs
+          );
+          
+          // Add to global test items array
+          this.testItems.push(testItem);
+          
+          // Add to plan-specific mapping
+          const planItems = this.testItemsByPlan.get(testPlan.name) || [];
+          planItems.push(testItem);
+          this.testItemsByPlan.set(testPlan.name, planItems);
+        });
+      });
+    });
+  }
+
+  private processLegacyTestPlan(): void {
+    this.templates?.forEach(template => {
+      this.tsscConfigs?.forEach(tsscConfig => {
         const itemName = tsscConfig.name || `${template}-${randomString()}`;
         
         this.testItems.push(
@@ -55,15 +113,26 @@ export class TestPlan {
   }
 
   hasTemplate(name: string): boolean {
-    return this.templates.includes(name);
+    if (this.testPlans) {
+      // New format: check across all test plans
+      return this.testPlans.some(plan => plan.templates.includes(name));
+    } else {
+      // Legacy format
+      return this.templates?.includes(name) || false;
+    }
   }
 
   hasTest(name: string): boolean {
-    return this.tests.includes(name);
+    if (this.testPlans) {
+      // New format: check across all test plans
+      return this.testPlans.some(plan => plan.tests.includes(name));
+    } else {
+      // Legacy format
+      return this.tests?.includes(name) || false;
+    }
   }
 
   getTestItems(): TestItem[] {
-    // Simply return the TestItems created in constructor
     return this.testItems;
   }
 
@@ -72,31 +141,150 @@ export class TestPlan {
     testItem: TestItem;
   }> {
     return this.testItems.map(testItem => ({
-      name: `${testItem.getTemplate()}[${testItem.getGitType()}-${testItem.getCIType()}-${testItem.getRegistryType()}]`,
+      name: `${testItem.getTemplate()}[${testItem.getGitType()}-${testItem.getCIType()}-${testItem.getRegistryType()}-${testItem.getACS()}]`,
       testItem
     }));
   }
 
+  // New methods for multiple test plans
+  getTestPlans(): TestPlanConfig[] {
+    return this.testPlans || [];
+  }
+
+  getTestPlanByName(name: string): TestPlanConfig | undefined {
+    return this.testPlans?.find(plan => plan.name === name);
+  }
+
+  getTestItemsByPlanName(planName: string): TestItem[] {
+    if (!this.testPlans) return [];
+    
+    const plan = this.getTestPlanByName(planName);
+    if (!plan) return [];
+
+    // Use the authoritative mapping if available
+    const planItems = this.testItemsByPlan.get(planName);
+    if (planItems && planItems.length > 0) {
+      return planItems;
+    }
+
+    // Fallback to name-based filtering for backward compatibility
+    return this.testItems.filter(item => 
+      item.getName().startsWith(`${planName}-`)
+    );
+  }
+
+  getTestsForPlan(planName: string): string[] {
+    const plan = this.getTestPlanByName(planName);
+    if (plan && plan.tests) {
+      return plan.tests;
+    }
+    return [];
+  }
+
+  getTestMatchPatternsForPlan(planName: string): string[] {
+    const tests = this.getTestsForPlan(planName);
+    if (tests.length === 0) {
+      return ['**/nonexistent.test.ts'];
+    }
+    
+    return tests.map(test => {
+      // Handle folder patterns (e.g., "ui", "tssc")
+      if (!test.includes('.test.ts')) {
+        return `tests/**/${test}/**/*.test.ts`;
+      }
+      // Handle specific test files (e.g., "ui/component.test.ts")
+      return `tests/**/${test}`;
+    });
+  }
+
+  getTestsForPlans(planNames: string[]): string[] {
+    const allTests: string[] = [];
+    for (const planName of planNames) {
+      const tests = this.getTestsForPlan(planName);
+      allTests.push(...tests);
+    }
+    return [...new Set(allTests)]; // Remove duplicates
+  }
+
+  getTestMatchPatternsForPlans(planNames: string[]): string[] {
+    const allPatterns: string[] = [];
+    for (const planName of planNames) {
+      const patterns = this.getTestMatchPatternsForPlan(planName);
+      allPatterns.push(...patterns);
+    }
+    return [...new Set(allPatterns)]; // Remove duplicates
+  }
+
   // Helper methods for validation
   isValid(): boolean {
-    return this.templates.length > 0 && this.tsscConfigs.length > 0;
+    if (this.testPlans) {
+      // New format: validate all test plans
+      return this.testPlans.length > 0 && 
+             this.testPlans.every(plan => 
+               plan.templates.length > 0 && plan.tssc.length > 0
+             );
+    } else {
+      // Legacy format
+      return (this.templates?.length || 0) > 0 && (this.tsscConfigs?.length || 0) > 0;
+    }
   }
 
   getTotalProjectCount(): number {
-    return this.templates.length * this.tsscConfigs.length;
+    if (this.testPlans) {
+      // New format: sum across all test plans
+      return this.testPlans.reduce((total, plan) => 
+        total + (plan.templates.length * plan.tssc.length), 0
+      );
+    } else {
+      // Legacy format
+      return (this.templates?.length || 0) * (this.tsscConfigs?.length || 0);
+    }
   }
 
   getTemplateNames(): string[] {
-    return [...this.templates];
+    if (this.testPlans) {
+      // New format: get unique templates across all plans
+      const allTemplates = this.testPlans.flatMap(plan => plan.templates);
+      return [...new Set(allTemplates)];
+    } else {
+      // Legacy format
+      return [...(this.templates || [])];
+    }
   }
 
   getTsscConfigNames(): string[] {
-    return this.tsscConfigs.map(config => `${config.git}-${config.ci}`);
+    if (this.testPlans) {
+      // New format: get unique config names across all plans
+      const allConfigs = this.testPlans.flatMap(plan => 
+        plan.tssc.map(config => `${config.git}-${config.ci}`)
+      );
+      return [...new Set(allConfigs)];
+    } else {
+      // Legacy format
+      return this.tsscConfigs?.map(config => `${config.git}-${config.ci}`) || [];
+    }
+  }
+
+  // Get test plan names (new format only)
+  getTestPlanNames(): string[] {
+    return this.testPlans?.map(plan => plan.name) || [];
   }
 
   // Test filtering methods
   getTests(): string[] {
-    return this.tests;
+    // If using multiple test plans format, aggregate tests from all plans
+    if (this.testPlans && Array.isArray(this.testPlans)) {
+      const allTests: string[] = [];
+      this.testPlans.forEach(plan => {
+        if (plan.tests && Array.isArray(plan.tests)) {
+          allTests.push(...plan.tests);
+        }
+      });
+      return allTests;
+    }
+    
+    // Fallback to legacy single test plan format
+    return this.tests || [];
   }
 
   /**
@@ -104,19 +292,22 @@ export class TestPlan {
    * Supports both folder patterns and specific test files
    */
   getTestMatchPatterns(): string[] {
-    if (this.tests.length === 0) {
+    const tests = this.getTests();
+    if (tests.length === 0) {
       // If no tests specified, return default pattern
       return ['**/*.test.ts'];
     }
 
-    return this.tests.map(test => {
+    return tests.map(test => {
       // If test ends with .test.ts, treat as specific file
       if (test.endsWith('.test.ts')) {
-        return `tests/**/${test}`;
+        // If test already starts with tests/, use as is, otherwise add tests/ prefix
+        return test.startsWith('tests/') ? test : `tests/**/${test}`;
       }
       // Otherwise, treat as folder name
       else {
-        return `tests/${test}/**/*.test.ts`;
+        // If test already starts with tests/, use as is, otherwise add tests/ prefix
+        return test.startsWith('tests/') ? `${test}/**/*.test.ts` : `tests/${test}/**/*.test.ts`;
       }
     });
   }
@@ -140,11 +331,12 @@ export class TestPlan {
    * Check if a specific test file should be included based on the tests array
    */
   shouldIncludeTest(testFilePath: string): boolean {
-    if (this.tests.length === 0) {
+    const tests = this.tests || [];
+    if (tests.length === 0) {
       return true; // Include all tests if no filtering specified
     }
 
-    return this.tests.some(test => {
+    return tests.some(test => {
       // If test ends with .test.ts, check for exact file match
       if (test.endsWith('.test.ts')) {
         return testFilePath.endsWith(test);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tests organized by named test plans, enabling separate backend and UI plan execution.
  * UI projects now include an auth setup and storage state for authenticated UI runs.

* **Configuration**
  * Test commands switched to plan-based selection (TESTPLAN_NAME) instead of env flags.
  * Test config now supports multiple nested test plans; legacy single-plan format still supported.
  * Runtime detects requested UI plans and falls back safely to E2E-only on parse errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->