### PR TITLE
[DNM] Test ci import

### DIFF
--- a/integration-tests/config/rhads-config
+++ b/integration-tests/config/rhads-config
@@ -1,4 +1,4 @@
-OCP="4.20"
+OCP="4.20,4.19,4.18"
 ACS="remote"
 REGISTRY="quay,artifactory,nexus"
 TPA="local"

--- a/integration-tests/config/rhads-config
+++ b/integration-tests/config/rhads-config
@@ -1,4 +1,4 @@
-OCP="4.20,4.19,4.18"
+OCP="4.21,4.20,4.19,4.18"
 ACS="remote"
 REGISTRY="quay,artifactory,nexus"
 TPA="local"

--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -7,11 +7,42 @@
         "git": "github",
         "ci": "tekton",
         "registry": "quay"
-      },{
-          "git": "gitlab",
-          "ci": "tekton",
-          "registry": "quay"
-        }],
+      },
+      {
+        "git": "gitlab",
+        "ci": "tekton",
+        "registry": "nexus"
+      },
+      {
+        "git": "gitlab",
+        "ci": "gitlabci",
+        "registry": "quay"
+      },
+      {
+        "git": "github",
+        "ci": "githubactions",
+        "registry": "artifactory"
+      },
+      {
+        "git": "github",
+        "ci": "azure",
+        "registry": "quay"
+      },
+      {
+        "git": "github",
+        "ci": "jenkins",
+        "registry": "quay"
+      },
+      {
+        "git": "gitlab",
+        "ci": "jenkins",
+        "registry": "quay"
+      },
+      {
+        "git": "bitbucket",
+        "ci": "jenkins",
+        "registry": "quay"
+      }],
       "tests": ["tssc/full_workflow.test.ts"]
     },
     {

--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -7,43 +7,6 @@
         "git": "github",
         "ci": "tekton",
         "registry": "quay"
-      },
-      {
-        "git": "gitlab",
-        "ci": "tekton",
-        "registry": "nexus"
-      },
-      {
-        "git": "gitlab",
-        "ci": "gitlabci",
-        "registry": "quay",
-        "tpa": "local",
-        "acs": "remote"
-      },
-      {
-        "git": "github",
-        "ci": "githubactions",
-        "registry": "artifactory"
-      },
-      {
-        "git": "github",
-        "ci": "azure",
-        "registry": "quay"
-      },
-      {
-        "git": "github",
-        "ci": "jenkins",
-        "registry": "quay"
-      },
-      {
-        "git": "gitlab",
-        "ci": "jenkins",
-        "registry": "quay"
-      },
-      {
-        "git": "bitbucket",
-        "ci": "jenkins",
-        "registry": "quay"
       }],
       "tests": ["tssc/full_workflow.test.ts"]
     },

--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -7,7 +7,11 @@
         "git": "github",
         "ci": "tekton",
         "registry": "quay"
-      }],
+      },{
+          "git": "gitlab",
+          "ci": "tekton",
+          "registry": "quay"
+        }],
       "tests": ["tssc/full_workflow.test.ts"]
     },
     {

--- a/integration-tests/config/testplan.json
+++ b/integration-tests/config/testplan.json
@@ -18,6 +18,10 @@
           "git": "github",
           "ci": "tekton",
           "registry": "quay"
+        },{
+          "git": "gitlab",
+          "ci": "tekton",
+          "registry": "quay"
         }
       ],
       "tests": ["templates/import_templates.test.ts"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded tested OpenShift versions to include OCP 4.18, 4.19, and 4.20.
  * Simplified the e2e test plan to a single CI/Git/registry configuration (GitLab/GitLab CI/Quay).
  * Added a GitLab/Tekton/Quay configuration for import-tests alongside the existing GitHub/Tekton/Quay entry.
  * Normalized test configuration formatting and ensured files end with a newline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->