### PR TITLE
Increase Azure API timeout to 90s and add retry logic to pipeline aut…

### DIFF
--- a/src/api/azure/azureClient.ts
+++ b/src/api/azure/azureClient.ts
@@ -29,7 +29,7 @@ export class AzureClient {
       host: config.host,
       organization: config.organization,
       pat: config.pat,
-      timeout: 30000, // 30s default
+      timeout: 90000,
     };
 
     this.httpClient = new AzureHttpClient(httpClientConfig);

--- a/src/api/azure/errors/azure.errors.ts
+++ b/src/api/azure/errors/azure.errors.ts
@@ -24,6 +24,12 @@ export class AzureNotFoundError extends NotFoundError {
   }
 }
 
+export function isTransientAzureError(error: unknown): boolean {
+  if (!(error instanceof AzureApiError)) return true;
+  const status = error.status;
+  return !status || status === 408 || status === 429 || status >= 500;
+}
+
 export class AzureBadRequestError extends BadRequestError {
   constructor(message = 'Azure bad request', status = 400, data?: any, cause?: unknown) {
     super(message, status, data, cause);

--- a/src/api/azure/services/azure-agent-pool.service.ts
+++ b/src/api/azure/services/azure-agent-pool.service.ts
@@ -1,3 +1,4 @@
+import retry from 'async-retry';
 import { AzureHttpClient } from '../http/azure-http.client';
 import { AgentQueue } from '../types/azure.types';
 import { AZURE_API_VERSIONS } from '../constants/api-versions';
@@ -38,21 +39,28 @@ export class AzureAgentPoolService {
   }
 
   public async authorizePipelineForAgentPool(pipelineId: number, poolId: number): Promise<void> {
-    try {
-      const payload = {
-        pipelines: [{ id: pipelineId, authorized: true }],
-        resource: {
-          id: poolId.toString(),
-          type: 'queue',
+    await retry(
+      async () => {
+        const payload = {
+          pipelines: [{ id: pipelineId, authorized: true }],
+          resource: {
+            id: poolId.toString(),
+            type: 'queue',
+          },
+        };
+        await this.client.patch(
+          `${this.project}/_apis/pipelines/pipelinePermissions/queue/${poolId}?api-version=${AZURE_API_VERSIONS.PIPELINE_PERMISSIONS}`,
+          payload
+        );
+      },
+      {
+        retries: 3,
+        minTimeout: 5000,
+        maxTimeout: 15000,
+        onRetry: (error, attempt) => {
+          this.logger.warn(`Retry attempt ${attempt}/3 to authorize pipeline ${pipelineId} for agent pool ${poolId}: ${error}`);
         },
-      };
-      await this.client.patch(
-        `${this.project}/_apis/pipelines/pipelinePermissions/queue/${poolId}?api-version=${AZURE_API_VERSIONS.PIPELINE_PERMISSIONS}`,
-        payload
-      );
-    } catch (error) {
-      this.logger.error(`Failed to authorize pipeline ${pipelineId} for agent pool ${poolId}: ${error}`);
-      throw error;
-    }
+      }
+    );
   }
 }

--- a/src/api/azure/services/azure-agent-pool.service.ts
+++ b/src/api/azure/services/azure-agent-pool.service.ts
@@ -1,7 +1,7 @@
 import retry from 'async-retry';
 import { AzureHttpClient } from '../http/azure-http.client';
 import { AgentQueue } from '../types/azure.types';
-import { AzureApiError } from '../errors/azure.errors';
+import { AzureApiError, isTransientAzureError } from '../errors/azure.errors';
 import { AZURE_API_VERSIONS } from '../constants/api-versions';
 import { LoggerFactory, Logger } from '../../../logger/logger';
 
@@ -56,13 +56,9 @@ export class AzureAgentPoolService {
               payload
             );
           } catch (error) {
-            if (error instanceof AzureApiError) {
-              const status = error.status;
-              const isTransient = !status || status === 408 || status === 429 || status >= 500;
-              if (!isTransient) {
-                bail(error);
-                return;
-              }
+            if (!isTransientAzureError(error)) {
+              bail(error as Error);
+              return;
             }
             throw error;
           }

--- a/src/api/azure/services/azure-agent-pool.service.ts
+++ b/src/api/azure/services/azure-agent-pool.service.ts
@@ -1,6 +1,7 @@
 import retry from 'async-retry';
 import { AzureHttpClient } from '../http/azure-http.client';
 import { AgentQueue } from '../types/azure.types';
+import { AzureApiError } from '../errors/azure.errors';
 import { AZURE_API_VERSIONS } from '../constants/api-versions';
 import { LoggerFactory, Logger } from '../../../logger/logger';
 
@@ -39,28 +40,47 @@ export class AzureAgentPoolService {
   }
 
   public async authorizePipelineForAgentPool(pipelineId: number, poolId: number): Promise<void> {
-    await retry(
-      async () => {
-        const payload = {
-          pipelines: [{ id: pipelineId, authorized: true }],
-          resource: {
-            id: poolId.toString(),
-            type: 'queue',
-          },
-        };
-        await this.client.patch(
-          `${this.project}/_apis/pipelines/pipelinePermissions/queue/${poolId}?api-version=${AZURE_API_VERSIONS.PIPELINE_PERMISSIONS}`,
-          payload
-        );
-      },
-      {
-        retries: 3,
-        minTimeout: 5000,
-        maxTimeout: 15000,
-        onRetry: (error, attempt) => {
-          this.logger.warn(`Retry attempt ${attempt}/3 to authorize pipeline ${pipelineId} for agent pool ${poolId}: ${error}`);
+    try {
+      await retry(
+        async (bail) => {
+          try {
+            const payload = {
+              pipelines: [{ id: pipelineId, authorized: true }],
+              resource: {
+                id: poolId.toString(),
+                type: 'queue',
+              },
+            };
+            await this.client.patch(
+              `${this.project}/_apis/pipelines/pipelinePermissions/queue/${poolId}?api-version=${AZURE_API_VERSIONS.PIPELINE_PERMISSIONS}`,
+              payload
+            );
+          } catch (error) {
+            if (error instanceof AzureApiError) {
+              const status = error.status;
+              const isTransient = !status || status === 408 || status === 429 || status >= 500;
+              if (!isTransient) {
+                bail(error);
+                return;
+              }
+            }
+            throw error;
+          }
         },
-      }
-    );
+        {
+          retries: 2,
+          minTimeout: 5000,
+          maxTimeout: 15000,
+          onRetry: (error: unknown, attempt: number) => {
+            const status = error instanceof AzureApiError ? error.status : undefined;
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.warn(`Retry attempt ${attempt}/2 to authorize pipeline ${pipelineId} for agent pool ${poolId}: ${message} (status: ${status})`);
+          },
+        }
+      );
+    } catch (error) {
+      this.logger.error(`Failed to authorize pipeline ${pipelineId} for agent pool ${poolId} after retries: ${error}`);
+      throw error;
+    }
   }
 }

--- a/src/api/azure/services/azure-variable-group.service.ts
+++ b/src/api/azure/services/azure-variable-group.service.ts
@@ -1,7 +1,7 @@
 import retry from 'async-retry';
 import { AzureHttpClient } from '../http/azure-http.client';
 import { VariableGroup } from '../types/azure.types';
-import { AzureApiError } from '../errors/azure.errors';
+import { AzureApiError, isTransientAzureError } from '../errors/azure.errors';
 import { AZURE_API_VERSIONS } from '../constants/api-versions';
 import { LoggerFactory, Logger } from '../../../logger/logger';
 
@@ -85,13 +85,9 @@ export class AzureVariableGroupService {
               payload
             );
           } catch (error) {
-            if (error instanceof AzureApiError) {
-              const status = error.status;
-              const isTransient = !status || status === 408 || status === 429 || status >= 500;
-              if (!isTransient) {
-                bail(error);
-                return;
-              }
+            if (!isTransientAzureError(error)) {
+              bail(error as Error);
+              return;
             }
             throw error;
           }

--- a/src/api/azure/services/azure-variable-group.service.ts
+++ b/src/api/azure/services/azure-variable-group.service.ts
@@ -1,6 +1,7 @@
 import retry from 'async-retry';
 import { AzureHttpClient } from '../http/azure-http.client';
 import { VariableGroup } from '../types/azure.types';
+import { AzureApiError } from '../errors/azure.errors';
 import { AZURE_API_VERSIONS } from '../constants/api-versions';
 import { LoggerFactory, Logger } from '../../../logger/logger';
 
@@ -68,29 +69,48 @@ export class AzureVariableGroupService {
     pipelineId: number,
     groupId: number
   ): Promise<void> {
-    await retry(
-      async () => {
-        const payload = {
-          pipelines: [{ id: pipelineId, authorized: true }],
-          resource: {
-            id: groupId.toString(),
-            type: 'variablegroup',
-          },
-        };
-        await this.client.patch(
-          `${this.project}/_apis/pipelines/pipelinePermissions/variablegroup/${groupId}?api-version=${AZURE_API_VERSIONS.PIPELINE_PERMISSIONS}`,
-          payload
-        );
-      },
-      {
-        retries: 3,
-        minTimeout: 5000,
-        maxTimeout: 15000,
-        onRetry: (error, attempt) => {
-          this.logger.warn(`Retry attempt ${attempt}/3 to authorize pipeline ${pipelineId} for variable group ${groupId}: ${error}`);
+    try {
+      await retry(
+        async (bail) => {
+          try {
+            const payload = {
+              pipelines: [{ id: pipelineId, authorized: true }],
+              resource: {
+                id: groupId.toString(),
+                type: 'variablegroup',
+              },
+            };
+            await this.client.patch(
+              `${this.project}/_apis/pipelines/pipelinePermissions/variablegroup/${groupId}?api-version=${AZURE_API_VERSIONS.PIPELINE_PERMISSIONS}`,
+              payload
+            );
+          } catch (error) {
+            if (error instanceof AzureApiError) {
+              const status = error.status;
+              const isTransient = !status || status === 408 || status === 429 || status >= 500;
+              if (!isTransient) {
+                bail(error);
+                return;
+              }
+            }
+            throw error;
+          }
         },
-      }
-    );
+        {
+          retries: 2,
+          minTimeout: 5000,
+          maxTimeout: 15000,
+          onRetry: (error: unknown, attempt: number) => {
+            const status = error instanceof AzureApiError ? error.status : undefined;
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.warn(`Retry attempt ${attempt}/2 to authorize pipeline ${pipelineId} for variable group ${groupId}: ${message} (status: ${status})`);
+          },
+        }
+      );
+    } catch (error) {
+      this.logger.error(`Failed to authorize pipeline ${pipelineId} for variable group ${groupId} after retries: ${error}`);
+      throw error;
+    }
   }
 
   public async deleteVariableGroup(groupId: number, projectId: string): Promise<void> {

--- a/src/api/azure/services/azure-variable-group.service.ts
+++ b/src/api/azure/services/azure-variable-group.service.ts
@@ -1,3 +1,4 @@
+import retry from 'async-retry';
 import { AzureHttpClient } from '../http/azure-http.client';
 import { VariableGroup } from '../types/azure.types';
 import { AZURE_API_VERSIONS } from '../constants/api-versions';
@@ -67,22 +68,29 @@ export class AzureVariableGroupService {
     pipelineId: number,
     groupId: number
   ): Promise<void> {
-    try {
-      const payload = {
-        pipelines: [{ id: pipelineId, authorized: true }],
-        resource: {
-          id: groupId.toString(),
-          type: 'variablegroup',
+    await retry(
+      async () => {
+        const payload = {
+          pipelines: [{ id: pipelineId, authorized: true }],
+          resource: {
+            id: groupId.toString(),
+            type: 'variablegroup',
+          },
+        };
+        await this.client.patch(
+          `${this.project}/_apis/pipelines/pipelinePermissions/variablegroup/${groupId}?api-version=${AZURE_API_VERSIONS.PIPELINE_PERMISSIONS}`,
+          payload
+        );
+      },
+      {
+        retries: 3,
+        minTimeout: 5000,
+        maxTimeout: 15000,
+        onRetry: (error, attempt) => {
+          this.logger.warn(`Retry attempt ${attempt}/3 to authorize pipeline ${pipelineId} for variable group ${groupId}: ${error}`);
         },
-      };
-      await this.client.patch(
-        `${this.project}/_apis/pipelines/pipelinePermissions/variablegroup/${groupId}?api-version=${AZURE_API_VERSIONS.PIPELINE_PERMISSIONS}`,
-        payload
-      );
-    } catch (error) {
-      this.logger.error(`Failed to authorize pipeline ${pipelineId} for variable group ${groupId}: ${error}`);
-      throw error;
-    }
+      }
+    );
   }
 
   public async deleteVariableGroup(groupId: number, projectId: string): Promise<void> {


### PR DESCRIPTION
From looking at https://app-artifact-browser.apps.rosa.konflux-qe.zmr9.p3.openshiftapps.com/rhtap-cli/e2e-4.19-dcmz4/artifacts-e2e/playwright-report/report.html#?testId=f0d1ffea69c573ab967f-942785631f4540270e22

It seems the requests are taking 15-20 seconds - and probably the PATCH is taking even more. 
I want to try bump the request timeout with some retry logic to be double-sure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased Azure HTTP client timeout to better handle longer requests.
  * Added automatic retry with backoff for pipeline and variable-group authorization; retry attempts are logged and final failures reported as occurring “after retries.”
  * Added transient-error classification to better distinguish retryable failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->